### PR TITLE
Admin menu fixes

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_adm_menu.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_adm_menu.lua
@@ -384,15 +384,23 @@ function SWEP:PrimaryAttack()
         end
 
         dframe.OnClose = function()
-            hook.Remove("Think", "Admin_Think")
+            hook.Remove("Think", "Admin_Think_" .. self:EntIndex())
         end
 
         dframe:MakePopup()
 
         local client = LocalPlayer()
-        hook.Add("Think", "Admin_Think", function()
-            if not client:Alive() then
+        hook.Add("Think", "Admin_Think_" .. self:EntIndex(), function()
+            if not dframe or not IsValid(dframe) then
+                hook.Remove("Think", "Admin_Think_" .. self:EntIndex())
+                return
+            end
+
+            local round_state = GetRoundState()
+            -- Automatically close the menu when the player dies or the round is in a state where they wouldn't have the weapon anymore
+            if not client:Alive() or (round_state ~= ROUND_ACTIVE and round_state ~= ROUND_POST) then
                 dframe:Close()
+                hook.Remove("Think", "Admin_Think_" .. self:EntIndex())
             end
         end)
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_adm_menu.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_adm_menu.lua
@@ -253,9 +253,14 @@ function SWEP:PrimaryAttack()
                 dtargetto:AddColumn("Players")
             end
 
+            local ownerSid64 = self:GetOwner():SteamID64()
             for _, p in PlayerIterator() do
+                -- Skip players who are true spectators, not just dead players
+                if p:IsSpec() and p:GetRole() == ROLE_NONE then continue end
+
                 local sid64 = p:SteamID64()
-                if sid64 == self:GetOwner():SteamID64() and CantTargetSelf(command) then continue end
+                if sid64 == ownerSid64 and CantTargetSelf(command) then continue end
+
                 dtarget:AddLine(p:Nick(), sid64)
                 if command == "send" then
                     dtargetto:AddLine(p:Nick(), sid64)


### PR DESCRIPTION
- Fixed errors in admin menu caused by it not being closed when the round moved to a state where the player was no longer and Admin and no longer had the weapon
- Fixed spectators showing in the admin menu target lists